### PR TITLE
Set the target build to Node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    [ "@babel/preset-env", { "targets": { "node": "current" } } ]
+    [ "@babel/preset-env", { "targets": { "node": "6" } } ]
   ],
   "plugins": [ "@babel/plugin-syntax-object-rest-spread" ]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Landon Schropp <schroppl@gmail.com>",
   "license": "MIT",
   "private": false,
+  "engines": { "node": ">= 6" },
   "files": [
     "build"
   ],


### PR DESCRIPTION
Node 6 is the LTS version of Node.js until April 2019. This is necessary to support AWS Lambda.